### PR TITLE
Update URI for IGV#commands

### DIFF
--- a/lib/igv.rb
+++ b/lib/igv.rb
@@ -162,7 +162,7 @@ class IGV
 
   def commands
     require 'launchy'
-    Launchy.open('https://github.com/igvteam/igv/wiki/Batch-commands')
+    Launchy.open('https://igv.org/doc/desktop/#UserGuide/tools/batch/#script-commands')
   end
 
   # Writes the value of "param" back to the response


### PR DESCRIPTION
I appreciate your efforts to maintain the Ruby-IGV library.

Original URI ('https://github.com/igvteam/igv/wiki/Batch-commands') for the IGV#commands method does not seem to show the command information now. How about update the URI to 'https://igv.org/doc/desktop/#UserGuide/tools/batch/#script-commands' ?