### PR TITLE
Make 2nd arguments of IGV#color_by and IGV#group optional (default=nil)

### DIFF
--- a/lib/igv.rb
+++ b/lib/igv.rb
@@ -559,7 +559,7 @@ class IGV
   # @example
   #   igv.color_by("SAMPLE")
   #   igv.color_by("TAG", "NM")
-  def color_by(option, tag)
+  def color_by(option, tag = nil)
     send :colorBy, option, tag
   end
 
@@ -572,7 +572,7 @@ class IGV
   # @example
   #   igv.group("SAMPLE")
   #   igv.group("TAG", "NM")
-  def group(option, tag)
+  def group(option, tag = nil)
     send :group, option, tag
   end
 

--- a/test/igv_test.rb
+++ b/test/igv_test.rb
@@ -26,6 +26,10 @@ class IGVTest < Test::Unit::TestCase
     assert_equal 'OK', @igv.goto('chr2')
     assert_equal 'OK', @igv.snapshot('test.png')
     assert_true File.exist?(File.expand_path('fixtures/test.png', __dir__))
+    assert_equal 'OK', @igv.color_by('READ_STRAND', nil)
+    assert_equal 'OK', @igv.color_by('READ_STRAND')
+    assert_equal 'OK', @igv.group('NONE', nil)
+    assert_equal 'OK', @igv.group('NONE')          
   end
 
   def teardown


### PR DESCRIPTION
According to comments on igv.rb, the 2nd arguments of IGV#color_by and IGV#group should be optional.
